### PR TITLE
Add support for VPC Alpha Constellation (Left) - 334480CB

### DIFF
--- a/www/scripts/bindingsData.py
+++ b/www/scripts/bindingsData.py
@@ -48,7 +48,7 @@ supportedDevices = OrderedDict([
     ('DS4', {'Template': 'ds4', 'HandledDevices': ['DS4', 'DualShock4']}),
     ('VPC-WarBRD-DELTA-Left', {'Template': 'vpc-warbrd-delta-left', 'HandledDevices': ['03EB2042']}),
     ('VPC-WarBRD-DELTA-Right', {'Template': 'vpc-warbrd-delta-right', 'HandledDevices': ['03EB2044']}),
-    ('VPC-ALPHA-Left', {'Template': 'vpc-alpha-left', 'HandledDevices': ['03EB2046','334483EB']}),
+    ('VPC-ALPHA-Left', {'Template': 'vpc-alpha-left', 'HandledDevices': ['03EB2046','334483EB', '334480CB']}),
     ('VPC-ALPHA-Right', {'Template': 'vpc-alpha-right', 'HandledDevices': ['03EB2048','334443EB','334440CB','334400CB','3344412F']}),
     ('VPC-ALPHA-Left-Custom', {'Template': 'vpc-alpha-left', 'HandledDevices': ['03EB9901']}),
     ('VPC-ALPHA-Right-Custom', {'Template': 'vpc-alpha-right', 'HandledDevices': ['03EB9902']}),
@@ -2146,6 +2146,56 @@ hotasDetails = {
         'Joy_29': {'Type': 'Digital', 'x': 2610, 'y': 1480, 'width': 1180}, # Left
         # Pinky button
         'Joy_2': {'Type': 'Digital', 'x': 2610, 'y': 1900, 'width': 1180},
+        # Break axis
+        'Joy_31': {'Type': 'Digital', 'x': 2610, 'y': 1750, 'width': 1180},
+        'Joy_UAxis': {'Type': 'Analogue', 'x': 2610, 'y': 1690, 'width': 1180},
+		# Joystick axis
+        'Joy_XAxis': {'Type': 'Analogue', 'x': 120, 'y': 1860, 'width': 1180},
+        'Joy_YAxis': {'Type': 'Analogue', 'x': 120, 'y': 1920, 'width': 1180},
+        'Joy_ZAxis': {'Type': 'Analogue', 'x': 120, 'y': 1980, 'width': 1180}, # Twist
+		# Mini-joysticks axis
+        'Joy_RXAxis': {'Type': 'Analogue', 'x': 2610, 'y': 510, 'width': 1180},
+        'Joy_RYAxis': {'Type': 'Analogue', 'x': 2610, 'y': 570, 'width': 1180},
+    },
+    '334480CB': { # VPC Alpha left
+        'displayName': 'VPC Alpha left',
+        'Joy_1': {'Type': 'Digital', 'x': 2610, 'y': 810, 'width': 1180}, # Flip Trigger first stage
+        'Joy_2': {'Type': 'Digital', 'x': 2610, 'y': 870, 'width': 1180}, # Flip Trigger second stage
+        'Joy_3': {'Type': 'Digital', 'x': 2610, 'y': 1060, 'width': 1180}, # Trigger first stage
+        'Joy_4': {'Type': 'Digital', 'x': 2610, 'y': 1120, 'width': 1180}, # Trigger second stage
+        'Joy_5': {'Type': 'Digital', 'x': 2610, 'y': 630, 'width': 1180}, # Mini-joystick push
+        'Joy_6': {'Type': 'Digital', 'x': 2610, 'y': 330, 'width': 1180}, # Red button
+        # 4-way hat top
+   		'Joy_7': {'Type': 'Digital', 'x': 120, 'y': 810, 'width': 1180}, # Push
+        'Joy_8': {'Type': 'Digital', 'x': 120, 'y': 570, 'width': 1180}, # Up
+        'Joy_9': {'Type': 'Digital', 'x': 120, 'y': 630, 'width': 1180}, # Right
+        'Joy_10': {'Type': 'Digital', 'x': 120, 'y': 690, 'width': 1180}, # Down 
+        'Joy_11': {'Type': 'Digital', 'x': 120, 'y': 750, 'width': 1180}, # Left
+        # Black button
+        'Joy_12': {'Type': 'Digital', 'x': 120, 'y': 920, 'width': 1180},        
+		# 4-way hat bottom
+        'Joy_13': {'Type': 'Digital', 'x': 120, 'y': 1340, 'width': 1180}, # Push		
+        'Joy_14': {'Type': 'Digital', 'x': 120, 'y': 1100, 'width': 1180}, # Up
+        'Joy_15': {'Type': 'Digital', 'x': 120, 'y': 1160, 'width': 1180}, # Right
+        'Joy_16': {'Type': 'Digital', 'x': 120, 'y': 1220, 'width': 1180}, # Down
+        'Joy_17': {'Type': 'Digital', 'x': 120, 'y': 1280, 'width': 1180}, # Left
+		# 2-way hat
+        'Joy_18': {'Type': 'Digital', 'x': 120, 'y': 450, 'width': 1180}, # Push
+        'Joy_19': {'Type': 'Digital', 'x': 120, 'y': 330, 'width': 1180}, # Up
+        'Joy_20': {'Type': 'Digital', 'x': 120, 'y': 390, 'width': 1180}, # Down
+        # Wheel
+        'Joy_21': {'Type': 'Digital', 'x': 120, 'y': 1690, 'width': 1180}, # Push second stage
+        'Joy_22': {'Type': 'Digital', 'x': 120, 'y': 1630, 'width': 1180}, # Push first stage
+        'Joy_23': {'Type': 'Digital', 'x': 120, 'y': 1570, 'width': 1180}, # Down
+        'Joy_24': {'Type': 'Digital', 'x': 120, 'y': 1510, 'width': 1180}, # Up
+        # Thumb hat
+        'Joy_25': {'Type': 'Digital', 'x': 2610, 'y': 1540, 'width': 1180}, # Push
+        'Joy_26': {'Type': 'Digital', 'x': 2610, 'y': 1300, 'width': 1180}, # Up
+        'Joy_27': {'Type': 'Digital', 'x': 2610, 'y': 1360, 'width': 1180}, # Righ
+        'Joy_28': {'Type': 'Digital', 'x': 2610, 'y': 1420, 'width': 1180}, # Down
+        'Joy_29': {'Type': 'Digital', 'x': 2610, 'y': 1480, 'width': 1180}, # Left
+        # Pinky button
+        'Joy_30': {'Type': 'Digital', 'x': 2610, 'y': 1900, 'width': 1180},
         # Break axis
         'Joy_31': {'Type': 'Digital', 'x': 2610, 'y': 1750, 'width': 1180},
         'Joy_UAxis': {'Type': 'Analogue', 'x': 2610, 'y': 1690, 'width': 1180},


### PR DESCRIPTION
Updated Virpil ID, same as existing VPC Constellation Alpha (Left) with ref 
at `.../www/res/vpc-alpha-left.jpg`

Support for VPC Alpha Left (Constellation) - Device ID: 334480CB
F/W version 20240323

See posts:
1. https://forums.frontier.co.uk/threads/edrefcard-v1-4-new-hosting-new-maintainers-the-follow-on-to-edrefcard-makes-a-printable-reference-card-of-your-controller-bindings.627609/post-10528717
2. https://forums.frontier.co.uk/threads/edrefcard-v1-4-new-hosting-new-maintainers-the-follow-on-to-edrefcard-makes-a-printable-reference-card-of-your-controller-bindings.627609/post-10529358